### PR TITLE
Update registration with more profile fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Attendance Tracker
 
-This simple web app tracks employee attendance. It now includes a basic authentication system. Users can register with a username and password which are stored in `localStorage`. A hard coded admin account (`admin` / `adminpass`) is available. After logging in, employees only see and add their own records while the admin can view everything and delete entries.
+This simple web app tracks employee attendance. It now includes a basic authentication system. Users can register with a username, password and additional profile information which are stored in `localStorage`. A hard coded admin account (`admin` / `adminpass`) is available. After logging in, employees only see and add their own records while the admin can view everything and delete entries.
+
+## Registration Fields
+
+When signing up a new employee account the following details are collected:
+
+- **Username**
+- **Password**
+- **Address**
+- **English Proficiency** (Beginner, Intermediate or Advanced)
+- **Hobby**
 
 Open `attendance.html` in a browser to use the tracker.

--- a/attendance.html
+++ b/attendance.html
@@ -82,6 +82,23 @@
             <label for="registerPassword">Password:</label>
             <input type="password" id="registerPassword" required>
         </div>
+        <div>
+            <label for="registerAddress">Address:</label>
+            <input type="text" id="registerAddress" required>
+        </div>
+        <div>
+            <label for="registerProficiency">English Proficiency:</label>
+            <select id="registerProficiency" required>
+                <option value="" disabled selected>Select level</option>
+                <option value="Beginner">Beginner</option>
+                <option value="Intermediate">Intermediate</option>
+                <option value="Advanced">Advanced</option>
+            </select>
+        </div>
+        <div>
+            <label for="registerHobby">Hobby:</label>
+            <input type="text" id="registerHobby" required>
+        </div>
         <button type="submit">Sign Up</button>
     </form>
     <p><a href="#" id="showLogin">Back to Login</a></p>
@@ -280,11 +297,21 @@ registerForm.addEventListener('submit', function(e) {
     e.preventDefault();
     const username = document.getElementById('registerUsername').value.trim();
     const password = document.getElementById('registerPassword').value;
+    const address = document.getElementById('registerAddress').value.trim();
+    const proficiency = document.getElementById('registerProficiency').value;
+    const hobby = document.getElementById('registerHobby').value.trim();
     if (users.find(u => u.username === username)) {
         alert('Username already exists');
         return;
     }
-    users.push({username, password, role: 'employee'});
+    users.push({
+        username,
+        password,
+        address,
+        proficiency,
+        hobby,
+        role: 'employee'
+    });
     localStorage.setItem(usersKey, JSON.stringify(users));
     alert('Registration successful! Please login.');
     registerForm.reset();


### PR DESCRIPTION
## Summary
- extend sign up form to collect address, English proficiency and hobby
- store the new details alongside username and password
- document the additional registration fields in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686a56eea95c832c979a30a58e4192d6